### PR TITLE
When the new session is created, set default window name

### DIFF
--- a/tmux_handler/tmux_handler.go
+++ b/tmux_handler/tmux_handler.go
@@ -104,7 +104,8 @@ func AttachSession(session_name string) {
 
 func CreateNewSession(new_session string, is_switched bool) {
 	var attach_cmd *exec.Cmd
-	attach_cmd = exec.Command("tmux", "new", "-s", new_session, "-d")
+	var window_name = new_session + "-main"
+	attach_cmd = exec.Command("tmux", "new", "-s", new_session, "-d", "-n", window_name)
 	attach_cmd.Stdin = os.Stdin
 	attach_cmd.Stdout = os.Stdout
 	attach_cmd.Stderr = os.Stderr
@@ -120,7 +121,8 @@ func CreateNewSession(new_session string, is_switched bool) {
 
 func CreateAndAttachSession(new_session string) {
 	var attach_cmd *exec.Cmd
-	attach_cmd = exec.Command("tmux", "new", "-s", new_session)
+	var window_name = new_session + "-main"
+	attach_cmd = exec.Command("tmux", "new", "-s", new_session, "-n", window_name)
 	attach_cmd.Stdin = os.Stdin
 	attach_cmd.Stdout = os.Stdout
 	attach_cmd.Stderr = os.Stderr


### PR DESCRIPTION
Default tmux window name is the shell name that you are using.
I'd like to set default window name like "new-session-name-main"